### PR TITLE
Fix arkanoid win restart

### DIFF
--- a/arkanoid/arkanoid.js
+++ b/arkanoid/arkanoid.js
@@ -46,8 +46,11 @@ function collisionDetection() {
                     score++;
                     document.getElementById('score').innerText = 'Score: ' + score;
                     if(score === brickRowCount * brickColumnCount){
+                        cancelAnimationFrame(animationId);
                         setTimeout(()=>{
-                            if(confirm('YOU WIN!\\n다시 시작할까요?')) window.location.reload();
+                            if(confirm('YOU WIN!\n다시 시작할까요?')) {
+                                resetGame();
+                            }
                         }, 100);
                     }
                 }


### PR DESCRIPTION
## Summary
- prevent full page reload when clearing all bricks
- reset arkanoid game state and restart the loop

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ffc2f32348325a6634772f1b78991